### PR TITLE
Fix cross compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,12 +7,13 @@ fn main() {
 
 use std::env;
 fn link_lib() {
-    let lib = if cfg!(target_arch = "x86_64") {
+	let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let lib = if target_arch == "x86_64" {
         "visa64"
-    } else if cfg!(target_arch = "x86") {
+    } else if target_arch == "x86" {
         "visa32"
     } else {
-        unimplemented!("target arch not implemented");
+        unimplemented!("target arch {} not implemented", target_arch);
     };
     println!("cargo:rustc-link-lib={}", lib);
 }

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
 
 use std::env;
 fn link_lib() {
-	let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let lib = if target_arch == "x86_64" {
         "visa64"
     } else if target_arch == "x86" {

--- a/src/prebind/bindings.rs
+++ b/src/prebind/bindings.rs
@@ -624,17 +624,17 @@ pub type ViPBusAddress = *mut ViBusAddress;
 pub type ViEventFilter = ViUInt32;
 pub type ViVAList = va_list;
 pub type ViHndlr = ::std::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "system" fn(
         vi: ViSession,
         eventType: ViEventType,
         event: ViEvent,
         userHandle: ViAddr,
     ) -> ViStatus,
 >;
-extern "C" {
+extern "system" {
     pub fn viOpenDefaultRM(vi: ViPSession) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viFindRsrc(
         sesn: ViSession,
         expr: ViConstString,
@@ -643,10 +643,10 @@ extern "C" {
         desc: *mut ViChar,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viFindNext(vi: ViFindList, desc: *mut ViChar) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viParseRsrc(
         rmSesn: ViSession,
         rsrcName: ViConstRsrc,
@@ -654,7 +654,7 @@ extern "C" {
         intfNum: ViPUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viParseRsrcEx(
         rmSesn: ViSession,
         rsrcName: ViConstRsrc,
@@ -665,7 +665,7 @@ extern "C" {
         aliasIfExists: *mut ViChar,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOpen(
         sesn: ViSession,
         name: ViConstRsrc,
@@ -674,26 +674,26 @@ extern "C" {
         vi: ViPSession,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viClose(vi: ViObject) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viSetAttribute(vi: ViObject, attrName: ViAttr, attrValue: ViAttrState) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGetAttribute(
         vi: ViObject,
         attrName: ViAttr,
         attrValue: *mut ::std::os::raw::c_void,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viStatusDesc(vi: ViObject, status: ViStatus, desc: *mut ViChar) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viTerminate(vi: ViObject, degree: ViUInt16, jobId: ViJobId) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viLock(
         vi: ViSession,
         lockType: ViAccessMode,
@@ -702,10 +702,10 @@ extern "C" {
         accessKey: *mut ViChar,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUnlock(vi: ViSession) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viEnableEvent(
         vi: ViSession,
         eventType: ViEventType,
@@ -713,13 +713,13 @@ extern "C" {
         context: ViEventFilter,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viDisableEvent(vi: ViSession, eventType: ViEventType, mechanism: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viDiscardEvents(vi: ViSession, eventType: ViEventType, mechanism: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viWaitOnEvent(
         vi: ViSession,
         inEventType: ViEventType,
@@ -728,7 +728,7 @@ extern "C" {
         outContext: ViPEvent,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viInstallHandler(
         vi: ViSession,
         eventType: ViEventType,
@@ -736,7 +736,7 @@ extern "C" {
         userHandle: ViAddr,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUninstallHandler(
         vi: ViSession,
         eventType: ViEventType,
@@ -744,13 +744,13 @@ extern "C" {
         userHandle: ViAddr,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viRead(vi: ViSession, buf: ViPBuf, cnt: ViUInt32, retCnt: ViPUInt32) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viReadAsync(vi: ViSession, buf: ViPBuf, cnt: ViUInt32, jobId: ViPJobId) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viReadToFile(
         vi: ViSession,
         filename: ViConstString,
@@ -758,14 +758,14 @@ extern "C" {
         retCnt: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viWrite(vi: ViSession, buf: ViConstBuf, cnt: ViUInt32, retCnt: ViPUInt32) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viWriteAsync(vi: ViSession, buf: ViConstBuf, cnt: ViUInt32, jobId: ViPJobId)
         -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viWriteFromFile(
         vi: ViSession,
         filename: ViConstString,
@@ -773,38 +773,38 @@ extern "C" {
         retCnt: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viAssertTrigger(vi: ViSession, protocol: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viReadSTB(vi: ViSession, status: ViPUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viClear(vi: ViSession) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viSetBuf(vi: ViSession, mask: ViUInt16, size: ViUInt32) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viFlush(vi: ViSession, mask: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viBufWrite(vi: ViSession, buf: ViConstBuf, cnt: ViUInt32, retCnt: ViPUInt32)
         -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viBufRead(vi: ViSession, buf: ViPBuf, cnt: ViUInt32, retCnt: ViPUInt32) -> ViStatus;
 }
 extern "C" {
     pub fn viPrintf(vi: ViSession, writeFmt: ViConstString, ...) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVPrintf(vi: ViSession, writeFmt: ViConstString, params: ViVAList) -> ViStatus;
 }
 extern "C" {
     pub fn viSPrintf(vi: ViSession, buf: ViPBuf, writeFmt: ViConstString, ...) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVSPrintf(
         vi: ViSession,
         buf: ViPBuf,
@@ -815,13 +815,13 @@ extern "C" {
 extern "C" {
     pub fn viScanf(vi: ViSession, readFmt: ViConstString, ...) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVScanf(vi: ViSession, readFmt: ViConstString, params: ViVAList) -> ViStatus;
 }
 extern "C" {
     pub fn viSScanf(vi: ViSession, buf: ViConstBuf, readFmt: ViConstString, ...) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVSScanf(
         vi: ViSession,
         buf: ViConstBuf,
@@ -837,7 +837,7 @@ extern "C" {
         ...
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVQueryf(
         vi: ViSession,
         writeFmt: ViConstString,
@@ -845,13 +845,13 @@ extern "C" {
         params: ViVAList,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn8(vi: ViSession, space: ViUInt16, offset: ViBusAddress, val8: ViPUInt8) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut8(vi: ViSession, space: ViUInt16, offset: ViBusAddress, val8: ViUInt8) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn16(
         vi: ViSession,
         space: ViUInt16,
@@ -859,7 +859,7 @@ extern "C" {
         val16: ViPUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut16(
         vi: ViSession,
         space: ViUInt16,
@@ -867,7 +867,7 @@ extern "C" {
         val16: ViUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn32(
         vi: ViSession,
         space: ViUInt16,
@@ -875,7 +875,7 @@ extern "C" {
         val32: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut32(
         vi: ViSession,
         space: ViUInt16,
@@ -883,7 +883,7 @@ extern "C" {
         val32: ViUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn64(
         vi: ViSession,
         space: ViUInt16,
@@ -891,7 +891,7 @@ extern "C" {
         val64: ViPUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut64(
         vi: ViSession,
         space: ViUInt16,
@@ -899,7 +899,7 @@ extern "C" {
         val64: ViUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn8Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -907,7 +907,7 @@ extern "C" {
         val8: ViPUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut8Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -915,7 +915,7 @@ extern "C" {
         val8: ViUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn16Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -923,7 +923,7 @@ extern "C" {
         val16: ViPUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut16Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -931,7 +931,7 @@ extern "C" {
         val16: ViUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn32Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -939,7 +939,7 @@ extern "C" {
         val32: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut32Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -947,7 +947,7 @@ extern "C" {
         val32: ViUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viIn64Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -955,7 +955,7 @@ extern "C" {
         val64: ViPUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viOut64Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -963,7 +963,7 @@ extern "C" {
         val64: ViUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn8(
         vi: ViSession,
         space: ViUInt16,
@@ -972,7 +972,7 @@ extern "C" {
         buf8: ViAUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut8(
         vi: ViSession,
         space: ViUInt16,
@@ -981,7 +981,7 @@ extern "C" {
         buf8: ViAUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn16(
         vi: ViSession,
         space: ViUInt16,
@@ -990,7 +990,7 @@ extern "C" {
         buf16: ViAUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut16(
         vi: ViSession,
         space: ViUInt16,
@@ -999,7 +999,7 @@ extern "C" {
         buf16: ViAUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn32(
         vi: ViSession,
         space: ViUInt16,
@@ -1008,7 +1008,7 @@ extern "C" {
         buf32: ViAUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut32(
         vi: ViSession,
         space: ViUInt16,
@@ -1017,7 +1017,7 @@ extern "C" {
         buf32: ViAUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn64(
         vi: ViSession,
         space: ViUInt16,
@@ -1026,7 +1026,7 @@ extern "C" {
         buf64: ViAUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut64(
         vi: ViSession,
         space: ViUInt16,
@@ -1035,7 +1035,7 @@ extern "C" {
         buf64: ViAUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn8Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1044,7 +1044,7 @@ extern "C" {
         buf8: ViAUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut8Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1053,7 +1053,7 @@ extern "C" {
         buf8: ViAUInt8,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn16Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1062,7 +1062,7 @@ extern "C" {
         buf16: ViAUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut16Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1071,7 +1071,7 @@ extern "C" {
         buf16: ViAUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn32Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1080,7 +1080,7 @@ extern "C" {
         buf32: ViAUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut32Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1089,7 +1089,7 @@ extern "C" {
         buf32: ViAUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveIn64Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1098,7 +1098,7 @@ extern "C" {
         buf64: ViAUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveOut64Ex(
         vi: ViSession,
         space: ViUInt16,
@@ -1107,7 +1107,7 @@ extern "C" {
         buf64: ViAUInt64,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMove(
         vi: ViSession,
         srcSpace: ViUInt16,
@@ -1119,7 +1119,7 @@ extern "C" {
         srcLength: ViBusSize,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveAsync(
         vi: ViSession,
         srcSpace: ViUInt16,
@@ -1132,7 +1132,7 @@ extern "C" {
         jobId: ViPJobId,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveEx(
         vi: ViSession,
         srcSpace: ViUInt16,
@@ -1144,7 +1144,7 @@ extern "C" {
         srcLength: ViBusSize,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMoveAsyncEx(
         vi: ViSession,
         srcSpace: ViUInt16,
@@ -1157,7 +1157,7 @@ extern "C" {
         jobId: ViPJobId,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMapAddress(
         vi: ViSession,
         mapSpace: ViUInt16,
@@ -1168,10 +1168,10 @@ extern "C" {
         address: ViPAddr,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUnmapAddress(vi: ViSession) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMapAddressEx(
         vi: ViSession,
         mapSpace: ViUInt16,
@@ -1182,52 +1182,52 @@ extern "C" {
         address: ViPAddr,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viPeek8(vi: ViSession, address: ViAddr, val8: ViPUInt8);
 }
-extern "C" {
+extern "system" {
     pub fn viPoke8(vi: ViSession, address: ViAddr, val8: ViUInt8);
 }
-extern "C" {
+extern "system" {
     pub fn viPeek16(vi: ViSession, address: ViAddr, val16: ViPUInt16);
 }
-extern "C" {
+extern "system" {
     pub fn viPoke16(vi: ViSession, address: ViAddr, val16: ViUInt16);
 }
-extern "C" {
+extern "system" {
     pub fn viPeek32(vi: ViSession, address: ViAddr, val32: ViPUInt32);
 }
-extern "C" {
+extern "system" {
     pub fn viPoke32(vi: ViSession, address: ViAddr, val32: ViUInt32);
 }
-extern "C" {
+extern "system" {
     pub fn viPeek64(vi: ViSession, address: ViAddr, val64: ViPUInt64);
 }
-extern "C" {
+extern "system" {
     pub fn viPoke64(vi: ViSession, address: ViAddr, val64: ViUInt64);
 }
-extern "C" {
+extern "system" {
     pub fn viMemAlloc(vi: ViSession, size: ViBusSize, offset: ViPBusAddress) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMemFree(vi: ViSession, offset: ViBusAddress) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMemAllocEx(vi: ViSession, size: ViBusSize, offset: ViPBusAddress64) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMemFreeEx(vi: ViSession, offset: ViBusAddress64) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGpibControlREN(vi: ViSession, mode: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGpibControlATN(vi: ViSession, mode: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGpibSendIFC(vi: ViSession) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGpibCommand(
         vi: ViSession,
         cmd: ViConstBuf,
@@ -1235,10 +1235,10 @@ extern "C" {
         retCnt: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viGpibPassControl(vi: ViSession, primAddr: ViUInt16, secAddr: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viVxiCommandQuery(
         vi: ViSession,
         mode: ViUInt16,
@@ -1246,13 +1246,13 @@ extern "C" {
         response: ViPUInt32,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viAssertUtilSignal(vi: ViSession, line: ViUInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viAssertIntrSignal(vi: ViSession, mode: ViInt16, statusID: ViUInt32) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viMapTrigger(
         vi: ViSession,
         trigSrc: ViInt16,
@@ -1260,10 +1260,10 @@ extern "C" {
         mode: ViUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUnmapTrigger(vi: ViSession, trigSrc: ViInt16, trigDest: ViInt16) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUsbControlOut(
         vi: ViSession,
         bmRequestType: ViInt16,
@@ -1274,7 +1274,7 @@ extern "C" {
         buf: ViConstBuf,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viUsbControlIn(
         vi: ViSession,
         bmRequestType: ViInt16,
@@ -1286,7 +1286,7 @@ extern "C" {
         retCnt: ViPUInt16,
     ) -> ViStatus;
 }
-extern "C" {
+extern "system" {
     pub fn viPxiReserveTriggers(
         vi: ViSession,
         cnt: ViInt16,


### PR DESCRIPTION
Fix cross compilation by checking the target arch of the crate being built rather than the target arch of the buildscript